### PR TITLE
Support Python 3 with "six" instead of running `2to3`

### DIFF
--- a/configshell/__init__.py
+++ b/configshell/__init__.py
@@ -20,8 +20,8 @@ if __name__ == "configshell":
     warn("'configshell' package name for configshell-fb is deprecated, please"
          + " instead import 'configshell_fb'", UserWarning, stacklevel=2)
 
-from log import Log
-from console import Console
-from shell import ConfigShell
-from node import ConfigNode, ExecutionError
-from prefs import Prefs
+from .console import Console
+from .log import Log
+from .node import ConfigNode, ExecutionError
+from .prefs import Prefs
+from .shell import ConfigShell

--- a/configshell/console.py
+++ b/configshell/console.py
@@ -15,14 +15,16 @@ License for the specific language governing permissions and limitations
 under the License.
 '''
 
-import re
-import sys
-import tty
-import prefs
-import struct
-import textwrap
 from fcntl import ioctl
+import re
+import six
+import struct
+import sys
 from termios import TIOCGWINSZ, TCSADRAIN, tcsetattr, tcgetattr
+import textwrap
+import tty
+
+from .prefs import Prefs
 
 # avoid requiring epydoc at runtime
 try:
@@ -68,7 +70,7 @@ class Console(object):
         self._stdout = stdout
         self._stdin = stdin
         self._stderr = stderr
-        self.prefs = prefs.Prefs()
+        self.prefs = Prefs()
 
     # Public methods
 
@@ -338,7 +340,7 @@ class Console(object):
         @return: The formated string.
         @rtype: C{string}
         '''
-        if isinstance(tree, basestring):
+        if isinstance(tree, six.string_types):
             return tree
 
         if tree.tag == 'section':

--- a/configshell/log.py
+++ b/configshell/log.py
@@ -15,12 +15,13 @@ License for the specific language governing permissions and limitations
 under the License.
 '''
 
+import inspect
 import os
 import time
-import prefs
-import inspect
-import console
 import traceback
+
+from .console import Console
+from .prefs import Prefs
 
 class Log(object):
     '''
@@ -51,8 +52,8 @@ class Log(object):
         @type file_level: str
         '''
         self.__dict__ = self.__borg_state
-        self.con = console.Console()
-        self.prefs = prefs.Prefs()
+        self.con = Console()
+        self.prefs = Prefs()
 
         if console_level:
             self.prefs['loglevel_console'] = console_level

--- a/configshell/node.py
+++ b/configshell/node.py
@@ -15,8 +15,9 @@ License for the specific language governing permissions and limitations
 under the License.
 '''
 
-import re
 import inspect
+import re
+import six
 
 class ExecutionError(Exception):
     pass
@@ -505,7 +506,7 @@ class ConfigNode(object):
         elif group not in self.list_config_groups():
             raise ExecutionError("Unknown configuration group: %s" % group)
 
-        for param, value in parameter.iteritems():
+        for param, value in six.iteritems(parameter):
             if param not in self.list_group_params(group):
                 raise ExecutionError("Unknown parameter %s in group '%s'."
                                      % (param, group))
@@ -1079,15 +1080,15 @@ class ConfigNode(object):
         def handle_input(input, raw):
             for key in input:
                 widget, pos = content.get_focus()
-                if unicode(key) == 'up':
+                if key == 'up':
                     if pos > 0:
                         content.set_focus(pos-1)
-                elif unicode(key) == 'down':
+                elif key == 'down':
                     try:
                         content.set_focus(pos+1)
                     except IndexError:
                         pass
-                elif unicode(key) == 'enter':
+                elif key == 'enter':
                     raise Selected(pos)
 
         content.set_focus(start_pos)
@@ -1263,7 +1264,7 @@ class ConfigNode(object):
                 bookmarks += "No bookmarks yet.\n"
             else:
                 for (bookmark, path) \
-                        in self.shell.prefs['bookmarks'].iteritems():
+                        in six.iteritems(self.shell.prefs['bookmarks']):
                     if len(bookmark) == 1:
                         bookmark += '\0'
                     underline = ''.ljust(len(bookmark), '-')
@@ -1731,7 +1732,7 @@ class ConfigNode(object):
             return []
         else:
             params = []
-            for p_name, p_def in self._configuration_groups[group].iteritems():
+            for p_name, p_def in six.iteritems(self._configuration_groups[group]):
                 (p_type, p_description, p_writable) = p_def
                 if writable is not None and p_writable != writable:
                     continue

--- a/configshell/prefs.py
+++ b/configshell/prefs.py
@@ -15,7 +15,7 @@ License for the specific language governing permissions and limitations
 under the License.
 '''
 
-import cPickle
+import six
 
 class Prefs(object):
     '''
@@ -114,7 +114,7 @@ class Prefs(object):
         @return: Iterates on the items in preferences.
         @rtype: yields items that are (key, value) pairs
         '''
-        return self._prefs.iteritems()
+        return six.iteritems(self._prefs)
 
     def save(self, filename=None):
         '''
@@ -129,7 +129,7 @@ class Prefs(object):
         if filename is not None:
             fsock = open(filename, 'wb')
             try:
-                cPickle.dump(self._prefs, fsock, 2)
+                six.moves.cPickle.dump(self._prefs, fsock, 2)
             finally:
                 fsock.close()
 
@@ -144,6 +144,6 @@ class Prefs(object):
         if filename is not None:
             fsock = open(filename, 'rb')
             try:
-                self._prefs = cPickle.load(fsock)
+                self._prefs = six.moves.cPickle.load(fsock)
             finally:
                 fsock.close()

--- a/configshell/shell.py
+++ b/configshell/shell.py
@@ -16,13 +16,14 @@ under the License.
 '''
 
 import os
+import six
 import sys
-from pyparsing import Empty, Group, OneOrMore, Optional, ParseResults, Regex, Suppress, Word
-from pyparsing import alphanums
+from pyparsing import (alphanums, Empty, Group, OneOrMore, Optional,
+                       ParseResults, Regex, Suppress, Word)
 
+from . import console
 from . import log
 from . import prefs
-from . import console
 from .node import ConfigNode, ExecutionError
 
 # A fix for frozen packages
@@ -168,7 +169,7 @@ class ConfigShell(object):
             self.log.warning("Could not load preferences file %s."
                              % self._prefs_file)
 
-        for pref, value in self.default_prefs.iteritems():
+        for pref, value in six.iteritems(self.default_prefs):
             if pref not in self.prefs:
                 self.prefs[pref] = value
 
@@ -449,7 +450,7 @@ class ConfigShell(object):
         for index in range(len(pparams)):
             if index < len(cmd_params):
                 current_parameters[cmd_params[index]] = pparams[index]
-        for key, value in kparams.iteritems():
+        for key, value in six.iteritems(kparams):
             current_parameters[key] = value
         self._completion_help_topic = command
         completion_method = target.get_completion_method(command)
@@ -597,7 +598,7 @@ class ConfigShell(object):
         current_parameters = {}
         for index in range(len(pparams)):
             current_parameters[cmd_params[index]] = pparams[index]
-        for key, value in kparams.iteritems():
+        for key, value in six.iteritems(kparams):
             current_parameters[key] = value
         completion_method = target.get_completion_method(command)
         if completion_method:
@@ -769,7 +770,7 @@ class ConfigShell(object):
             try:
                 readline.parse_and_bind("%s: complete" % self.complete_key)
                 readline.set_completer(self._complete)
-                cmdline = raw_input(self._get_prompt()).strip()
+                cmdline = six.moves.input(self._get_prompt()).strip()
             except EOFError:
                 self.con.raw_write('exit\n')
                 cmdline = "exit"

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,9 @@ setup(
     maintainer_email = 'agrover@redhat.com',
     url = 'http://github.com/agrover/configshell-fb',
     packages = ['configshell', 'configshell_fb'],
-    use_2to3 = True,
+    classifiers = [
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: Apache Software License",
+    ],
     )


### PR DESCRIPTION
 * Replace dict.iteritems() with six.iteritems(dict)
 * Use six.string_types instead of basestring
 * Remove calls to unicode() in the handle_input() function called by
   Urwid: it is not necessary. However, during my tests, I observed
   that the Urwid listbox displayed for `cd` is broken: I see garbage
   on the screen when moving the cursor.
 * Use six.moves to import pickle on Python 3 or cPickle on Python 2
 * Use six.moves to call input() on Python 3 or raw_input() on Python 2
 * Add classifiers to setup.py
 * Sort imports

Signed-off-by: Christophe Vu-Brugier <cvubrugier@fastmail.fm>