### PR TITLE
fixes to debian package build scripts

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -23,7 +23,7 @@ build-python%:
 	echo "debug: $@"
 	python$* setup.py build
 
-override_dh_auto_build: $(PYTHON3:%=build-python%)
+override_dh_auto_build: $(PYTHON3:%=build-python%) $(PYTHON2:%=build-python%)
 	dh_auto_build
 
 
@@ -31,7 +31,7 @@ install-python%:
 	echo "debug: $@"
 	python$* setup.py install --root=$(install_dir) --install-layout=deb
 
-override_dh_auto_install: $(PYTHON3:%=install-python%)
+override_dh_auto_install: $(PYTHON3:%=install-python%) $(PYTHON2:%=install-python%)
 	dh_auto_install
 
 


### PR DESCRIPTION
I found this tweak necessary to build packages for Debian 8 (jessie) with sbuild.